### PR TITLE
[Reviewer: Andy] add capability to restrict which processes receive ato mapping

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+libnss-ato (0.2-clearwater1) unstable; urgency=low
+
+  * hard coded process whitelist. fixes issues modifying users.
+
+ -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Fri, 18 Dec 2015 09:21:45 +0000
+
 libnss-ato (0.2-1) unstable; urgency=low
 
   * strip \n from group read in /etc/libnss-ato.conf (thanks Kyler Laird)
 
-  -- Pietro Donatini <donatini@dm.unibo.it>  Tue Sep  1 14:27:10 CEST 2009
+ -- Pietro Donatini <donatini@dm.unibo.it>  Tue, 1 Sep 2015 14:27:10 +0100 
 
 libnss-ato (0.1-1) unstable; urgency=low
 

--- a/libnss_ato.c
+++ b/libnss_ato.c
@@ -59,8 +59,6 @@ const char *VALID_PROC_NAMES[] = {"sshd",
  * Extra lines are comments (not processed).
  */
 
-
-
 struct passwd *
 read_conf() 
 {
@@ -162,7 +160,6 @@ int should_find_user(void)
   // Process name didn't match any that we want.
   return FALSE;
 }
-
 
 enum nss_status
 _nss_ato_getpwnam_r( const char *name, 


### PR DESCRIPTION
Adding in function to find the process id, then get its name. This can then be compared against the list provided at the top of the file, and only return the user mapping if it is a whitelisted process. otherwise it  will return that the user was not found. 

This should avoid the problem of all possible users existing when trying to add/modify a user etc.
