### PR TITLE
[Reviewer: Adam] Use the home directory from /etc/passwd

### DIFF
--- a/libnss_ato.c
+++ b/libnss_ato.c
@@ -64,6 +64,7 @@ read_conf()
 {
 	FILE *fd;
 	struct passwd *conf;
+	struct passwd *conf2;
 
 	if ((fd = fopen(CONF_FILE, "r")) == NULL ) {
 		return NULL;
@@ -77,7 +78,14 @@ read_conf()
 		conf->pw_gid = MIN_GID_NUMBER;
 
 	fclose(fd);
-	return conf;
+
+	/* Now we've got the UID to match to, get the full entry from
+	 * /etc/passwd. This means we don't need to specify the right home directory in
+	 * our conf file. */
+
+	conf2 = getpwuid(conf->pw_uid);
+
+	return conf2;
 }
 
 /* 


### PR DESCRIPTION
I found that while the username from /etc/libnss-ato.conf was ignored, the home directory wasn't, leading to portability problems. This uses the one from /etc/passwd instead.
